### PR TITLE
add raw-thrift server (only used in tests for now)

### DIFF
--- a/thrift-rpc.go
+++ b/thrift-rpc.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type TRpcServer struct {
+	server thrift.TServer
+	socket *thrift.TServerSocket
+}
+
+func NewTRpcServer(listen string, handler thrift.TProcessor, prot thrift.TProtocolFactory) (*TRpcServer, error) {
+	transport, err := thrift.NewTServerSocket(listen)
+
+	if err != nil {
+		return nil, err
+	}
+	server := thrift.NewTSimpleServer4(
+		handler,
+		transport,
+		thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()),
+		prot,
+	)
+
+	return &TRpcServer{server, transport}, nil
+}
+
+func (t *TRpcServer) Listen() error {
+	return t.socket.Listen()
+}
+
+func (t *TRpcServer) Serve() error {
+	return t.server.Serve()
+}
+
+func (t *TRpcServer) Addr() net.Addr {
+	return t.socket.Addr()
+}
+
+func (t *TRpcServer) Close() {
+	t.server.Stop()
+	t.socket.Close()
+}
+
+func (t *TRpcServer) GetClientTransport() (thrift.TTransport, error) {
+	transport, err := thrift.NewTSocket(t.Addr().String())
+	if err != nil {
+		return nil, err
+	}
+	if err = transport.Open(); err != nil {
+		return nil, err
+	}
+
+	return thrift.NewTFramedTransport(transport), nil
+}


### PR DESCRIPTION
just wanted to compare thrift-over-http vs not over http.

```
BenchmarkTBinaryHTTP-8         130139 ns/op     41620 B/op      125 allocs/op
BenchmarkTCompactHTTP-8        127828 ns/op     41459 B/op      128 allocs/op
BenchmarkTBinaryRaw-8           69471 ns/op      1327 B/op       42 allocs/op
BenchmarkTCompactRaw-8          69332 ns/op      1326 B/op       42 allocs/op
BenchmarkConcurrentHttp-8       91400 ns/op     47007 B/op      309 allocs/op
BenchmarkConcurrentRaw-8        30667 ns/op      4252 B/op      215 allocs/op
BenchmarkHandlerUncompressed-8  12174 ns/op       544 B/op       13 allocs/op
BenchmarkHandlerCompressed-8    23040 ns/op       624 B/op       18 allocs/op
```
