### PR TITLE
parameterize key counts

### DIFF
--- a/cmd/load/keypool.go
+++ b/cmd/load/keypool.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/foursquare/quiver/gen"
 	"github.com/foursquare/quiver/util"
 )
+
+func (l *Load) pickKeyCount() int {
+	return int(math.Min(math.Abs(rand.ExpFloat64()*l.keysPerReqSpread)+l.keysPerReqMin, l.keysPerReqMax))
+}
 
 // Re-fetches a new batch of keys every freq, swapping out the in-use set.
 func (l *Load) startKeyFetcher(freq time.Duration) {
@@ -37,7 +43,8 @@ func (l *Load) setKeys() error {
 	}
 }
 
-func (l *Load) randomKeys(count int) [][]byte {
+func (l *Load) randomKeys() [][]byte {
+	count := l.pickKeyCount()
 	indexes := make([]int, count)
 	l.RLock()
 	for i := 0; i < count; i++ {
@@ -57,4 +64,25 @@ func (l *Load) randomKey() []byte {
 	l.RLock()
 	defer l.RUnlock()
 	return l.keys[rand.Intn(len(l.keys))]
+}
+
+func (l *Load) printKeySpread() {
+	seen := make(map[int]int)
+	for i := 0; i < 100000; i++ {
+		k := l.pickKeyCount()
+		seen[k] = seen[k] + 1
+	}
+
+	var keys []int
+	max := 0
+	for k, v := range seen {
+		keys = append(keys, k)
+		if v > max {
+			max = v
+		}
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		fmt.Println(k, "\t", seen[k], "\t", strings.Repeat("#", seen[k]*100/max))
+	}
 }

--- a/cmd/load/workers.go
+++ b/cmd/load/workers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/hex"
 	"log"
-	"math"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -59,8 +58,7 @@ func (l *Load) sendOne(client *gen.HFileServiceClient, diff *gen.HFileServiceCli
 
 // Generate and send a random GetValuesSingle request.
 func (l *Load) sendSingle(client *gen.HFileServiceClient, diff *gen.HFileServiceClient) {
-	numKeys := int(math.Abs(rand.ExpFloat64()*10) + 1)
-	keys := l.randomKeys(numKeys)
+	keys := l.randomKeys()
 	r := &gen.SingleHFileKeyRequest{HfileName: &l.collection, SortedKeys: keys}
 
 	before := time.Now()
@@ -91,8 +89,7 @@ func (l *Load) sendSingle(client *gen.HFileServiceClient, diff *gen.HFileService
 
 // Generate and send a random GetValuesSingle request.
 func (l *Load) sendMulti(client *gen.HFileServiceClient, diff *gen.HFileServiceClient) {
-	numKeys := int(math.Abs(rand.ExpFloat64()*10) + 1)
-	keys := l.randomKeys(numKeys)
+	keys := l.randomKeys()
 	r := &gen.SingleHFileKeyRequest{HfileName: &l.collection, SortedKeys: keys}
 
 	before := time.Now()
@@ -122,8 +119,8 @@ func (l *Load) sendMulti(client *gen.HFileServiceClient, diff *gen.HFileServiceC
 
 // Generate and send a random GetValuesSingle request.
 func (l *Load) sendPrefixes(client *gen.HFileServiceClient, diff *gen.HFileServiceClient) {
-	numKeys := int(math.Abs(rand.ExpFloat64()*10) + 1)
-	fullKeys := l.randomKeys(numKeys)
+
+	fullKeys := l.randomKeys()
 	prefixes := make([][]byte, len(fullKeys))
 
 	for i, v := range fullKeys {


### PR DESCRIPTION
also include -print-spread to print a visual representation of the distrubution of key counts
