### PR TITLE
delay joining service discovery

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -33,10 +33,14 @@ func (r *Registrations) Connect() {
 	}
 }
 
-func (r *Registrations) Join(hostname, base string, configs []*hfile.CollectionConfig) {
+func (r *Registrations) Join(hostname, base string, configs []*hfile.CollectionConfig, wait time.Duration) {
 	if hostname == "localhost" {
 		log.Fatal("invalid hostname for service discovery registration:", hostname)
 	}
+
+	log.Println("Waiting to join service discovery", wait)
+	time.Sleep(wait)
+	log.Println("Joining service discovery...")
 
 	r.Lock()
 	defer r.Unlock()


### PR DESCRIPTION
listen-and-serve blocks forever (unless it errors) but ideally we shouldn't register until
after it has started listening. we could start our own listener, register and then call serve,
but ListenAndServe gets us TCP keepalive for free, so a simple async sleep-and-join is quick and easy.
