### PR TITLE
golang seems to think 4gb is a 'huge buffer'

### DIFF
--- a/hfile/load-file.go
+++ b/hfile/load-file.go
@@ -2,7 +2,7 @@ package hfile
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -46,9 +46,11 @@ func loadFile(name, path string, method LoadMethod) ([]byte, error) {
 		log.Printf("[Reader.NewReader] Locked %s.\n", name)
 
 	case CopiedToMem:
+		defer f.Close()
+
 		log.Printf("[Reader.NewReader] Reading in %s (%.02fmb)...\n", name, sizeMb)
-		data, err := ioutil.ReadFile(path)
-		if err != nil {
+		data := make([]byte, fi.Size())
+		if _, err := io.ReadFull(f, data); err != nil {
 			log.Printf("[Reader.NewReader] Error reading in %s: %s\n", name, err.Error())
 			return nil, err
 		}

--- a/hfile/reader.go
+++ b/hfile/reader.go
@@ -129,6 +129,8 @@ func (r *Reader) loadIndex(data []byte) error {
 
 	i := r.dataIndexOffset
 
+	r.index = make([]Block, 0, r.dataIndexCount)
+
 	if bytes.Compare(data[i:i+8], IndexMagic) != 0 {
 		return errors.New("bad data index magic")
 	}


### PR DESCRIPTION
ioutil.ReadFile won't pre-alloc a buffer of size > 1gb (excepted from ioutil.go):

```
      // Don't preallocate a huge buffer, just in case.
      if size := fi.Size(); size < 1e9 {
```

(from https://golang.org/src/io/ioutil/ioutil.go?s=1464:1510#L60 )

Thus reading a 4gb hfile results in 8gb alloc'ed while growing the buffer.
