### PR TITLE
copy bytes straight from network to mem

### DIFF
--- a/hfile/load-file.go
+++ b/hfile/load-file.go
@@ -26,11 +26,11 @@ This memory will never be freed -- don't use this unless you are sure that is wh
 Putting gigs and gigs of static, long-lived data on the gc's managed heap has the potential to
 throw off any heuristics which to use the total size of the heap (e.g. maintain some % free space).
 */
-func offheapMalloc(size int) []byte {
+func offheapMalloc(size int64) []byte {
 	hdr := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(C.malloc(C.size_t(size)))),
-		Len:  size,
-		Cap:  size,
+		Len:  int(size),
+		Cap:  int(size),
 	}
 	return *(*[]byte)(unsafe.Pointer(&hdr))
 }
@@ -75,7 +75,7 @@ func loadFile(name, path string, method LoadMethod) ([]byte, error) {
 		defer f.Close()
 
 		log.Printf("[Reader.NewReader] Reading in %s (%.02fmb)...\n", name, sizeMb)
-		data := offheapMalloc(int(fi.Size()))
+		data := offheapMalloc(fi.Size())
 		if _, err := io.ReadFull(f, data); err != nil {
 			log.Printf("[Reader.NewReader] Error reading in %s: %s\n", name, err.Error())
 			return nil, err

--- a/hfile/reader.go
+++ b/hfile/reader.go
@@ -51,14 +51,16 @@ type Block struct {
 }
 
 func NewReader(name, path string, load LoadMethod, debug bool) (*Reader, error) {
-	return NewReaderFromConfig(CollectionConfig{name, path, path, load, debug, name, "", "", ""})
+	return NewReaderFromConfig(CollectionConfig{name, path, path, nil, load, debug, name, "", "", ""})
 }
 
 func NewReaderFromConfig(cfg CollectionConfig) (*Reader, error) {
 	hfile := new(Reader)
 	hfile.CollectionConfig = cfg
 
-	if data, err := loadFile(cfg.Name, cfg.LocalPath, cfg.LoadMethod); err != nil {
+	if cfg.cachedContent != nil {
+		hfile.data = *cfg.cachedContent
+	} else if data, err := loadFile(cfg.Name, cfg.LocalPath, cfg.LoadMethod); err != nil {
 		return nil, err
 	} else {
 		hfile.data = data

--- a/hfile/testdata.go
+++ b/hfile/testdata.go
@@ -79,5 +79,5 @@ func TestdataCollectionSet(name string, count int, compress bool, load LoadMetho
 	} else if err != nil {
 		return nil, err
 	}
-	return LoadCollections([]*CollectionConfig{{name, path, path, load, false, name, "", "", ""}}, os.TempDir(), false, nil)
+	return LoadCollections([]*CollectionConfig{{name, path, path, nil, load, false, name, "", "", ""}}, os.TempDir(), false, nil)
 }

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func main() {
 	log.Println("Loading collections...")
 
 	cs, err := hfile.LoadCollections(configs, Settings.cachePath, Settings.downloadOnly, stats)
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This might shave some time off startup, avoiding flushing to disk during fetch and then reading back.

Not sure if we can actually trust Content-Length though so this might be a bad idea as far as alloc, and it feels very special-case.
