### PR TITLE
Rename all uses of 'header' with 'trailer'.

### DIFF
--- a/hfile/README.md
+++ b/hfile/README.md
@@ -11,7 +11,7 @@ On-disk, an HFile consists of:
   
   - some number of blocks,
   - an index, specifying the offset and length of each block along with its first key
-  - a fixed-size, fixed-layout header (or trailer actually) of metadata
+  - a fixed-size, fixed-layout trailer of metadata
 
 Each block contains some number of key-value pairs, each in the form of two 4-byte sizes `i` and `j`, followed by `i` bytes of key and `j` bytes of value.
 


### PR DESCRIPTION
Calling the trailer a header in the code was unnecessarily confusing
to n00bs such as myself. The HFile documentation and source code
uses the term 'trailer' pretty much exclusively, so we might as well
follow suit.
