### PR TITLE
Add all trailer fields to the servicez output.

### DIFF
--- a/hfile/iterator.go
+++ b/hfile/iterator.go
@@ -25,8 +25,8 @@ type Iterator struct {
 
 func NewIterator(r *Reader) *Iterator {
 	var buf []byte
-	if r.compressionCodec > CompressionNone {
-		buf = make([]byte, int(float64(r.totalUncompressedDataBytes/uint64(len(r.index)))*1.5))
+	if r.CompressionCodec > CompressionNone {
+		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes /uint64(len(r.index)))*1.5))
 	}
 
 	it := Iterator{r, 0, nil, 0, buf, nil, nil, OrderedOps{nil}}

--- a/hfile/scanner.go
+++ b/hfile/scanner.go
@@ -23,8 +23,8 @@ type Scanner struct {
 
 func NewScanner(r *Reader) *Scanner {
 	var buf []byte
-	if r.compressionCodec > CompressionNone {
-		buf = make([]byte, int(float64(r.totalUncompressedDataBytes/uint64(len(r.index)))*1.5))
+	if r.CompressionCodec > CompressionNone {
+		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes /uint64(len(r.index)))*1.5))
 	}
 	return &Scanner{r, 0, nil, nil, buf, true, OrderedOps{nil}}
 }


### PR DESCRIPTION
This required making them exported, but I see no harm in that.
In fact it's more uniform, since EntryCount was already exported.
