### PR TITLE
read subblocks and subblock chunks generated by BlockCompressorStream

### DIFF
--- a/hfile/reader.go
+++ b/hfile/reader.go
@@ -213,12 +213,15 @@ func (r *Reader) GetBlockBuf(i int, dst []byte) ([]byte, error) {
 	case CompressionNone:
 		dst = r.data[block.offset : block.offset+uint64(block.size)]
 	case CompressionSnappy:
-		uncompressedByteSize := binary.BigEndian.Uint32(r.data[block.offset : block.offset+4])
+		p := block.offset
+		uncompressedByteSize := binary.BigEndian.Uint32(r.data[p : p+4])
+		p += 4
 		if uncompressedByteSize != block.size {
 			return nil, errors.New("mismatched uncompressed block size")
 		}
-		compressedByteSize := binary.BigEndian.Uint32(r.data[block.offset+4 : block.offset+8])
-		compressedBytes := r.data[block.offset+8 : block.offset+8+uint64(compressedByteSize)]
+		compressedByteSize := binary.BigEndian.Uint32(r.data[p : p+4])
+		p += 4
+		compressedBytes := r.data[p : p+uint64(compressedByteSize)]
 		dst, err = snappy.Decode(dst, compressedBytes)
 		if err != nil {
 			return nil, err

--- a/hfile/reader.go
+++ b/hfile/reader.go
@@ -213,6 +213,11 @@ func (r *Reader) GetBlockBuf(i int, dst []byte) ([]byte, error) {
 	case CompressionNone:
 		dst = r.data[block.offset : block.offset+uint64(block.size)]
 	case CompressionSnappy:
+		// If our pre-allocated buffer too small, alloc replacement up front, to make sure Decode doesn't.
+		if len(dst) < int(block.size) {
+			dst = make([]byte, block.size)
+		}
+
 		p := block.offset
 		uncompressedByteSize := binary.BigEndian.Uint32(r.data[p : p+4])
 		p += 4


### PR DESCRIPTION
SnappyCompressor internally uses `BlockCompressorStream`, which writes "blocks" of compressed data.

These are NOT the "blocks" in the hfile sense. A "block" of an hfile may, when written by `BlockCompressorStream` write out many of what it calls "blocks". To avoid confusion, in this code, we shall call these "subblocks".

Unfortunately the confusing usages of "block" do not stop there.

BlockCompressorStream described the "blocks" (subblocks) that it writes thus[1]:
"Each block contains the uncompressed length for the block, followed by one or more length-prefixed _blocks_ of compressed data." (emphasis mine)

Yes, that is a third, distinct, "block".

In the hope that we might, with luck, navigate this correctly, we'll refer to these as "chunks" of "subblocks".

Thus, reading a "block" of an hfile we read its "subblocks" in a loop, inside of which we, in a nested loop, read the subblock's chunks.

1: http://grepcode.com/file/repo1.maven.org/maven2/org.apache.hadoop/hadoop-common/0.22.0/org/apache/hadoop/io/compress/BlockCompressorStream.java?av=f
