### PR TITLE
Extract the contents of the FileInfo block.

### DIFF
--- a/hfile/iterator.go
+++ b/hfile/iterator.go
@@ -26,7 +26,7 @@ type Iterator struct {
 func NewIterator(r *Reader) *Iterator {
 	var buf []byte
 	if r.CompressionCodec > CompressionNone {
-		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes /uint64(len(r.index)))*1.5))
+		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes/uint64(len(r.index)))*1.5))
 	}
 
 	it := Iterator{r, 0, nil, 0, buf, nil, nil, OrderedOps{nil}}

--- a/hfile/scanner.go
+++ b/hfile/scanner.go
@@ -24,7 +24,7 @@ type Scanner struct {
 func NewScanner(r *Reader) *Scanner {
 	var buf []byte
 	if r.CompressionCodec > CompressionNone {
-		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes /uint64(len(r.index)))*1.5))
+		buf = make([]byte, int(float64(r.TotalUncompressedDataBytes/uint64(len(r.index)))*1.5))
 	}
 	return &Scanner{r, 0, nil, nil, buf, true, OrderedOps{nil}}
 }

--- a/hfile/vint_test.go
+++ b/hfile/vint_test.go
@@ -3,11 +3,34 @@
 package hfile
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// Map from hex input to (value, len).
+type vl struct {
+	val int
+	len int
+}
+
+var testData = map[string]vl{
+	"8f8d":               vl{141, 2},
+	"8e9999":             vl{0x9999, 3},
+	"00":                 vl{0, 1},
+	"10":                 vl{0x10, 1},
+	"ff":                 vl{-1, 1},
+	"7f":                 vl{127, 1},
+	"804011111111111111": vl{-286331154, 9}, // 80 size = 9
+	"87aa":               vl{-171, 2},       // 87 size = 2
+	"885555555555555555": vl{1431655765, 9}, // 80 size = 9
+	"8955555555555555":   vl{1431655765, 8},
+	"86aaff":             vl{-43776, 3},
+	"8faa":               vl{170, 2}, // 8f size = 2
+	"90":                 vl{-112, 1},
+}
 
 func fromHex(t *testing.T, s string) []byte {
 	b, err := hex.DecodeString(s)
@@ -15,61 +38,27 @@ func fromHex(t *testing.T, s string) []byte {
 	return b
 }
 
+func TestVIntAndLen(t *testing.T) {
+	for key, value := range testData {
+		x, l := vintAndLen(fromHex(t, key))
+		assert.Equal(t, int32(value.val), int32(x))
+		assert.Equal(t, value.len, l)
+	}
+}
+
 func TestVInt(t *testing.T) {
-	x, l := vintAndLen(fromHex(t, "8f8d"))
-	assert.Equal(t, 141, x)
-	assert.Equal(t, 2, l)
+	for key, value := range testData {
+		x, err := vint(bytes.NewReader(fromHex(t, key)))
+		assert.Nil(t, err)
+		assert.Equal(t, int32(value.val), int32(x))
+	}
+}
 
-	x, l = vintAndLen(fromHex(t, "8e9999"))
-	assert.Equal(t, 0x9999, x)
-	assert.Equal(t, 3, l)
-
-	x, l = vintAndLen(fromHex(t, "00"))
-	assert.Equal(t, 0, x)
-	assert.Equal(t, 1, l)
-
-	x, l = vintAndLen(fromHex(t, "10"))
-	assert.Equal(t, 0x10, x)
-	assert.Equal(t, 1, l)
-
-	x, l = vintAndLen(fromHex(t, "ff"))
-	assert.Equal(t, -1, x)
-	assert.Equal(t, 1, l)
-
-	x, l = vintAndLen(fromHex(t, "7f"))
-	assert.Equal(t, 127, x)
-	assert.Equal(t, 1, l)
-
-	// 80 size = 9
-	x, l = vintAndLen(fromHex(t, "804011111111111111"))
-	assert.Equal(t, int32(-286331154), int32(x))
-	assert.Equal(t, 9, l)
-
-	// 87 size = 2
-	x, l = vintAndLen(fromHex(t, "87aa"))
-	assert.Equal(t, -171, x)
-	assert.Equal(t, 2, l)
-
-	// 80 size = 9
-	x, l = vintAndLen(fromHex(t, "885555555555555555"))
-	assert.Equal(t, int32(1431655765), int32(x))
-	assert.Equal(t, 9, l)
-
-	x, l = vintAndLen(fromHex(t, "8955555555555555"))
-	assert.Equal(t, int32(1431655765), int32(x))
-	assert.Equal(t, 8, l)
-
-	x, l = vintAndLen(fromHex(t, "86aaff"))
-	assert.Equal(t, -43776, x)
-	assert.Equal(t, 3, l)
-
-	// 8f size = 2
-	x, l = vintAndLen(fromHex(t, "8faa"))
-	assert.Equal(t, 170, x)
-	assert.Equal(t, 2, l)
-
-	x, l = vintAndLen(fromHex(t, "90"))
-	assert.Equal(t, -112, x)
-	assert.Equal(t, 1, l)
-
+func TestVIntErrors(t *testing.T) {
+	for key, _ := range testData {
+		buf := fromHex(t, key)
+		truncatedBuf := buf[0 : len(buf)-1]
+		_, err := vint(bytes.NewReader(truncatedBuf))
+		assert.NotNil(t, err)
+	}
 }

--- a/hfile/writer.go
+++ b/hfile/writer.go
@@ -25,7 +25,7 @@ type Writer struct {
 	curBlockBuf      *bytes.Buffer
 	curBlockFirstKey []byte
 
-	blocks []Block
+	blocks  []Block
 	trailer Trailer
 
 	OrderedOps
@@ -120,7 +120,15 @@ func (w *Writer) Close() error {
 		}
 	}
 
+	if err := w.flushFileInfo(); err != nil {
+		return err
+	}
+
 	if err := w.flushIndex(); err != nil {
+		return err
+	}
+
+	if err := w.flushMetaIndex(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Those fields will be visible in the servicez output.

Required a fix to the writer, to ensure that the FileInfoOffset is correctly written to the trailer. Also fixed MetaIndexOffset, while I was at it.

Note that tests will fail until you delete testdata/*, so the test code can regenerate new hfiles with good trailers.
