### PR TITLE
Minor formatting issue: format bool as bool

### DIFF
--- a/hfile/scanner.go
+++ b/hfile/scanner.go
@@ -69,7 +69,7 @@ func (s *Scanner) GetFirst(key []byte) ([]byte, error, bool) {
 
 	if !ok {
 		if s.reader.Debug {
-			log.Printf("[Scanner.GetFirst] No Block for key: %s (err: %s, found: %s)\n", hex.EncodeToString(key), err, ok)
+			log.Printf("[Scanner.GetFirst] No Block for key: %s (err: %s, found: %t)\n", hex.EncodeToString(key), err, ok)
 		}
 		return nil, err, ok
 	}


### PR DESCRIPTION
before:
2016/05/09 22:02:43 [Scanner.GetFirst] No Block for key: 68656c6c6f
(err: %!s(<nil>), found: %!s(bool=false))

after:
2016/05/09 22:06:42 [Scanner.GetFirst] No Block for key: 68656c6c6f
(err: %!s(<nil>), found: false)
