### PR TITLE
new option -no-copy-to-mem that serves from disk

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -57,7 +57,9 @@ func ConfigsFromCommandline(args []string) []*hfile.CollectionConfig {
 		}
 
 		loadMethod := hfile.CopiedToMem
-		if Settings.mlock {
+		if Settings.onDisk {
+			loadMethod = hfile.OnDisk
+		} else if Settings.mlock {
 			loadMethod = hfile.MemlockFile
 		}
 
@@ -99,7 +101,10 @@ func ConfigsFromJsonUrl(url string) []*hfile.CollectionConfig {
 			name := fmt.Sprintf("%s/%d", spec.Collection, spec.Partition)
 
 			loadMethod := hfile.CopiedToMem
-			if Settings.mlock {
+
+			if Settings.onDisk {
+				loadMethod = hfile.OnDisk
+			} else if Settings.mlock {
 				loadMethod = hfile.MemlockFile
 			}
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,8 @@ type SettingDefs struct {
 
 	bloom int
 
-	mlock bool
+	mlock  bool
+	onDisk bool
 
 	configJsonUrl string
 
@@ -57,6 +58,8 @@ func readSettings() []string {
 	flag.IntVar(&s.bloom, "bloom", 0, "bloom filter wrong-positive % (or 0 to disable): lower numbers use more RAM but filter more queries.")
 
 	flag.BoolVar(&s.downloadOnly, "download-only", false, "exit after downloading remote files to local cache.")
+
+	flag.BoolVar(&s.onDisk, "mnolock", false, "mmap files in memory rather than copy to heap, but don't mlock.")
 
 	flag.BoolVar(&s.mlock, "mlock", false, "mlock mapped files in memory rather than copy to heap.")
 


### PR DESCRIPTION
uses existing feature that was exposed for tests

performance seems pretty good, actually.  tested on a
large (2.2g) file that couldn't be malloc'd on my machine
and got ~3ms perf, which might be acceptable in some
scenarios
