### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 sudo: false
 install:
   - export CXX="g++-4.8" CC="gcc-4.8" CPP="g++-4.8"
-  - go get -v -t ./...
+  - go get -d -v -t ./...
 addons:
   apt:
     sources:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ BUILD_TIME=`date`, by `whoami`, on `hostname`
 LDFLAGS=-X \"main.version=${VERSION}\" -X \"main.buildTime=${BUILD_TIME}\"
 
 build:
+	go get github.com/kardianos/govendor
+	govendor sync
+	go test ./...
 	go build -ldflags "${LDFLAGS}"
+
+benchmark:
+	go test -bench . -benchtime 5s -test.benchmem
 
 install: uninstall
 	go install -ldflags "${LDFLAGS}"


### PR DESCRIPTION
I've amended a few important things here. Previously the travis build only
attempted to go build the binary with some useful flags. Now the travis build
does:

* correctly sets up the vendoring, this probably worked by accident before. 😭
* runs tests! curse you past me
* doesn't attempt to install with the go get, so no errors.