### PR TITLE
use go:generate instead of make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ _testmain.go
 
 # vendoring
 /vendor/*/
+
+# go:generate
+version.go

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,17 @@
-VERSION=`git describe --always`
-BUILD_TIME=`date`, by `whoami`, on `hostname`
-
-LDFLAGS=-X \"main.version=${VERSION}\" -X \"main.buildTime=${BUILD_TIME}\"
-
 build:
 	go get github.com/kardianos/govendor
 	govendor sync
+	go generate
 	go test ./...
-	go build -ldflags "${LDFLAGS}"
+	go build
 
 benchmark:
+	go generate
 	go test -bench . -benchtime 5s -test.benchmem
 
 install: uninstall
-	go install -ldflags "${LDFLAGS}"
+	go generate
+	go install
 
 uninstall:
 	rm ${GOPATH}/bin/quiver

--- a/genver.sh
+++ b/genver.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# genver.sh -- called by go:generate to create version.go
+
+echo "package main
+var version string = \"`git describe --always`\"
+var buildTime = \"`date`, by `whoami`, on `hostname`\"
+"

--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
 // Copyright (C) 2015 Foursquare Labs Inc.
+//go:generate sh -c "./genver.sh > version.go"
 
 package main
 
@@ -20,9 +21,6 @@ import (
 	"github.com/foursquare/fsgo/report"
 	"github.com/foursquare/quiver/hfile"
 )
-
-var version string = "HEAD?"
-var buildTime string = "unknown?"
 
 type SettingDefs struct {
 	port    int


### PR DESCRIPTION
## What
* embed version info with `go generate` instead of `make build` (make build still works and calls `go generate`)

## Why
* `go generate` is marginally easier to integrate into 3rd party build tool workflow (because it manages working dir)

## Tradeoffs
* this breaks `go get` (but govendor already does that)
* this drops a `version.go` file which can stick around and get stale; `-ldflags` is better here because it provides defaults