### PR TITLE
add flag and functionality for rate-limited hfile fetch

### DIFF
--- a/hfile/testdata.go
+++ b/hfile/testdata.go
@@ -79,5 +79,5 @@ func TestdataCollectionSet(name string, count int, compress bool, load LoadMetho
 	} else if err != nil {
 		return nil, err
 	}
-	return LoadCollections([]*CollectionConfig{{name, path, path, nil, load, false, name, "", "", ""}}, os.TempDir(), false, nil)
+	return LoadCollections([]*CollectionConfig{{name, path, path, nil, load, false, name, "", "", ""}}, os.TempDir(), false, 0, nil)
 }

--- a/main.go
+++ b/main.go
@@ -32,7 +32,8 @@ type SettingDefs struct {
 
 	debug bool
 
-	bloom int
+	bloom      int
+	bytesLimit float64
 
 	mlock  bool
 	onDisk bool
@@ -56,6 +57,7 @@ func readSettings() []string {
 	flag.BoolVar(&s.debug, "debug", false, "print more output")
 
 	flag.IntVar(&s.bloom, "bloom", 0, "bloom filter wrong-positive % (or 0 to disable): lower numbers use more RAM but filter more queries.")
+	flag.Float64Var(&s.bytesLimit, "rate-limit-bytes", 0, "limit downloads to bytes/sec, default is no limit ")
 
 	flag.BoolVar(&s.downloadOnly, "download-only", false, "exit after downloading remote files to local cache.")
 
@@ -121,7 +123,7 @@ func main() {
 
 	log.Println("Loading collections...")
 
-	cs, err := hfile.LoadCollections(configs, Settings.cachePath, Settings.downloadOnly, stats)
+	cs, err := hfile.LoadCollections(configs, Settings.cachePath, Settings.downloadOnly, Settings.bytesLimit, stats)
 
 	if err != nil {
 		log.Fatal(err)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,6 +63,12 @@
 			"revisionTime": "2017-05-09T15:16:33Z"
 		},
 		{
+			"checksumSHA1": "Om1yAM4c5mXN8PFUjH2rgFObzrs=",
+			"path": "github.com/fujiwara/shapeio",
+			"revision": "c073257dd7455637a1fa51201a9865a14ecb7f20",
+			"revisionTime": "2017-06-02T07:21:23Z"
+		},
+		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"path": "github.com/golang/snappy",
 			"revision": "553a641470496b2327abcac10b36396bd98e45c9",
@@ -121,6 +127,18 @@
 			"path": "github.com/stretchr/testify/suite",
 			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
 			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "61147c48b25b599e5b561d2e9c4f3e1ef489ca41",
+			"revisionTime": "2017-03-19T02:15:06Z"
+		},
+		{
+			"checksumSHA1": "HoCvrd3hEhsFeBOdEw7cbcfyk50=",
+			"path": "golang.org/x/time/rate",
+			"revision": "fbb02b2291d28baffd63558aa44b4b56f178d650",
+			"revisionTime": "2018-04-12T16:56:04Z"
 		}
 	],
 	"rootPath": "github.com/foursquare/quiver"


### PR DESCRIPTION
new command line flag: `-rate-limit-bytes`: limit bytes/sec of hfile downloads.

The default of 0 disables new functionality. The third-party `io.Reader` is not created or used. The original, unmodified `resp.Body` is the `io.Reader`.