### PR TITLE
fix go vet errors required for go1.12

### DIFF
--- a/cmd/listserving/list-collections.go
+++ b/cmd/listserving/list-collections.go
@@ -22,7 +22,7 @@ func removeWebhdfs(s string) string {
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("usage: %s hfileserver")
+		fmt.Printf("usage: %s hfileserver\n", os.Args[0])
 		os.Exit(1)
 	}
 

--- a/cmd/load/workers.go
+++ b/cmd/load/workers.go
@@ -211,7 +211,8 @@ func (l *Load) sendPrefixes(client *gen.HFileServiceClient, diff *gen.HFileServi
 						log.Printf("[DIFF-GetValuesForPrefixes] Missing from orig: %s", hex.EncodeToString([]byte(k)))
 					}
 				}
-				log.Println("\n")
+				log.Println()
+				log.Println()
 			} else {
 				log.Printf("[DIFF-GetValuesForPrefixes] req: %v\n \torig: %v\n\n\tdiff: %v\n", r, resp, diffResp)
 			}

--- a/hfile/scanner.go
+++ b/hfile/scanner.go
@@ -89,7 +89,7 @@ func (s *Scanner) GetAll(key []byte) ([][]byte, error) {
 
 	if !ok {
 		if s.reader.Debug {
-			log.Printf("[Scanner.GetAll] No Block for key: %s (err: %s, found: %s)\n", hex.EncodeToString(key), err, ok)
+			log.Printf("[Scanner.GetAll] No Block for key: %s (err: %s, found: %v)\n", hex.EncodeToString(key), err, ok)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
```┌─(cy@kudu:~/go/src/github.com/foursquare/quiver)               
└─(2:21)% go version            
go version go1.12.2 linux/amd64 

┌─(cy@kudu:~/go/src/github.com/foursquare/quiver)               
└─(19)% go test ./...           
# github.com/foursquare/quiver/hfile                            
hfile/scanner.go:92:4: Printf format %s has arg ok of wrong type bool                                                           
# github.com/foursquare/quiver/cmd/listserving                  
cmd/listserving/list-collections.go:25:3: Println call has possible formatting directive %s                                     
# github.com/foursquare/quiver/cmd/load                         
cmd/load/workers.go:214:5: Println arg list ends with redundant newline                                                         
ok      github.com/foursquare/quiver    0.313s                  
?       github.com/foursquare/quiver/cmd/dummyserver    [no test files]                                                         
FAIL    github.com/foursquare/quiver/hfile [build failed]       
ok      github.com/foursquare/quiver/hfile/lru  (cached)        
ok      github.com/foursquare/quiver/util       (cached) ```